### PR TITLE
refactor DI using tsyringe

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,17 @@ The application allows you to:
 - Delete folders
 
 All folder data is stored in Supabase.
+
+## Dependency Injection
+
+The application uses a simple wrapper around [tsyringe](https://github.com/microsoft/tsyringe) for dependency injection. You can resolve tokens normally or override the implementation when resolving:
+
+```ts
+const container = DependencyContainer.getInstance();
+
+// Resolve the default implementation
+const service = container.resolve(tSomeService);
+
+// Override with a custom class
+const custom = container.resolve(tSomeService, { useClass: CustomService });
+```

--- a/app/infrastructure/browser/package.json
+++ b/app/infrastructure/browser/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@repo/domain": "*",
-    "@repo/ioc": "*"
+    "@repo/ioc": "*",
+    "tsyringe": "^4.8.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "*",

--- a/app/infrastructure/browser/src/repositories/browser-vault.repository.ts
+++ b/app/infrastructure/browser/src/repositories/browser-vault.repository.ts
@@ -1,6 +1,8 @@
 import { VaultEntity } from '@repo/domain/entities/vault.entity';
 import { VaultRepository } from '@repo/domain/repositories/vault.repository';
+import { injectable } from 'tsyringe';
 
+@injectable()
 export class BrowserVaultRepository implements VaultRepository {
   getById(_id: string): Promise<VaultEntity | null> {
     throw new Error('Method not implemented.');

--- a/app/infrastructure/browser/tsconfig.json
+++ b/app/infrastructure/browser/tsconfig.json
@@ -7,7 +7,8 @@
     "paths": {
       "@repo/infrastructure-browser/*": ["./*"]
     },
-    "composite": true
+    "composite": true,
+    "experimentalDecorators": true
   },
   "include": ["./src/*.ts", "./src/**/*.ts"],
   "references": [

--- a/app/infrastructure/supabase/package.json
+++ b/app/infrastructure/supabase/package.json
@@ -25,6 +25,7 @@
     "zod": "~3.25.67",
     "@repo/ioc": "*",
     "@repo/domain": "*",
-    "@supabase/supabase-js": "^2.50.2"
+    "@supabase/supabase-js": "^2.50.2",
+    "tsyringe": "^4.8.0"
   }
 }

--- a/app/infrastructure/supabase/src/repositories/supabase-folder.repository.ts
+++ b/app/infrastructure/supabase/src/repositories/supabase-folder.repository.ts
@@ -4,22 +4,18 @@ import {
 } from '@repo/domain/entities/folder.entity';
 import type { FolderRepository } from '@repo/domain/repositories/folder.repository';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { DependencyContainer } from '@repo/ioc/container';
+import type { Factory } from '@repo/ioc/container';
+import { injectable, inject } from 'tsyringe';
 import { tSupabaseClient } from '../supabase-client';
 
-export const createSupabaseFolderRepository = (
-  container: DependencyContainer
-): FolderRepository => {
-  const client = container.resolve(tSupabaseClient);
-  return new SupabaseFolderRepository(client);
-};
+export const createSupabaseFolderRepository: Factory<FolderRepository> = (container) =>
+  container.resolve(SupabaseFolderRepository);
 
+@injectable()
 export class SupabaseFolderRepository implements FolderRepository {
-  private readonly supabaseClient: SupabaseClient;
-
-  constructor(supabaseClient: SupabaseClient) {
-    this.supabaseClient = supabaseClient;
-  }
+  constructor(
+    @inject(tSupabaseClient) private readonly supabaseClient: SupabaseClient
+  ) {}
 
   async getById(id: string): Promise<FolderEntity | null> {
     const { data, error } = await this.supabaseClient

--- a/app/infrastructure/supabase/src/repositories/supabase-user.repository.ts
+++ b/app/infrastructure/supabase/src/repositories/supabase-user.repository.ts
@@ -1,22 +1,18 @@
 import type { UserRepository } from '@repo/domain/repositories/user.repository';
 import { UserEntity, parseUserEntity } from '@repo/domain/entities/user.entity';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { DependencyContainer } from '@repo/ioc/container';
+import type { Factory } from '@repo/ioc/container';
+import { injectable, inject } from 'tsyringe';
 import { tSupabaseClient } from '../supabase-client';
 
-export const createSupabaseUserRepository = (
-  container: DependencyContainer
-): UserRepository => {
-  const client = container.resolve(tSupabaseClient);
-  return new SupabaseUserRepository(client);
-};
+export const createSupabaseUserRepository: Factory<UserRepository> = (container) =>
+  container.resolve(SupabaseUserRepository);
 
+@injectable()
 export class SupabaseUserRepository implements UserRepository {
-  private readonly client: SupabaseClient;
-
-  constructor(client: SupabaseClient) {
-    this.client = client;
-  }
+  constructor(
+    @inject(tSupabaseClient) private readonly client: SupabaseClient
+  ) {}
 
   async getByEmail(email: string): Promise<UserEntity | null> {
     const { data, error } = await this.client

--- a/app/infrastructure/supabase/src/repositories/supabase-vault.repository.ts
+++ b/app/infrastructure/supabase/src/repositories/supabase-vault.repository.ts
@@ -4,22 +4,18 @@ import {
 } from '@repo/domain/entities/vault.entity';
 import type { VaultRepository } from '@repo/domain/repositories/vault.repository';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { DependencyContainer } from '@repo/ioc/container';
+import type { Factory } from '@repo/ioc/container';
+import { injectable, inject } from 'tsyringe';
 import { tSupabaseClient } from '../supabase-client';
 
-export const createSupabaseVaultRepository = (
-  container: DependencyContainer
-): VaultRepository => {
-  const client = container.resolve(tSupabaseClient);
-  return new SupabaseVaultRepository(client);
-};
+export const createSupabaseVaultRepository: Factory<VaultRepository> = (container) =>
+  container.resolve(SupabaseVaultRepository);
 
+@injectable()
 export class SupabaseVaultRepository implements VaultRepository {
-  private readonly supabaseClient: SupabaseClient;
-
-  constructor(supabaseClient: SupabaseClient) {
-    this.supabaseClient = supabaseClient;
-  }
+  constructor(
+    @inject(tSupabaseClient) private readonly supabaseClient: SupabaseClient
+  ) {}
 
   async getById(id: string): Promise<VaultEntity | null> {
     const { data, error } = await this.supabaseClient

--- a/app/infrastructure/supabase/src/services/supabase-auth.service.ts
+++ b/app/infrastructure/supabase/src/services/supabase-auth.service.ts
@@ -7,21 +7,18 @@ import type {
   OAuthProvider,
 } from '@repo/domain/services/auth.service';
 import { SupabaseClient } from '@supabase/supabase-js';
+import { injectable, inject } from 'tsyringe';
 import { tAuthRedirectUrl, tSupabaseClient } from '../supabase-client';
-export const createSupabaseAuthService: Factory<AuthService> = (container) => {
-  const client = container.resolve(tSupabaseClient);
-  const redirectUrl = container.resolve(tAuthRedirectUrl);
-  return new SupabaseAuthService(client, redirectUrl);
-};
 
+export const createSupabaseAuthService: Factory<AuthService> = (container) =>
+  container.resolve(SupabaseAuthService);
+
+@injectable()
 export class SupabaseAuthService implements AuthService {
-  private readonly client: SupabaseClient;
-  private readonly redirectUrl: string;
-
-  constructor(client: SupabaseClient, redirectUrl: string) {
-    this.redirectUrl = redirectUrl;
-    this.client = client;
-  }
+  constructor(
+    @inject(tSupabaseClient) private readonly client: SupabaseClient,
+    @inject(tAuthRedirectUrl) private readonly redirectUrl: string
+  ) {}
 
   async loginWithEmailPassword(
     input: LoginWithEmailPasswordInput

--- a/app/infrastructure/supabase/tsconfig.json
+++ b/app/infrastructure/supabase/tsconfig.json
@@ -7,7 +7,8 @@
     "paths": {
       "@repo/infrastructure-supabase/*": ["./*"]
     },
-    "composite": true
+    "composite": true,
+    "experimentalDecorators": true
   },
   "include": ["./src/*.ts", "./src/**/*.ts"],
   "references": [

--- a/packages/ioc/package.json
+++ b/packages/ioc/package.json
@@ -17,5 +17,8 @@
     "@repo/typescript-config": "*",
     "@repo/eslint-config": "*",
     "typescript": "5.8.2"
+  },
+  "dependencies": {
+    "tsyringe": "^4.8.0"
   }
 }

--- a/packages/ioc/src/token.ts
+++ b/packages/ioc/src/token.ts
@@ -1,5 +1,5 @@
-import { Token } from './container';
+import type { InjectionToken } from 'tsyringe';
 
-export const createToken = <T>(name: string): Token<T> => {
-  return Symbol(name) as Token<T>;
+export const createToken = <T>(name: string): InjectionToken<T> => {
+  return name as unknown as InjectionToken<T>;
 };


### PR DESCRIPTION
## Summary
- refactor `DependencyContainer.resolve` to accept provider overrides via `ResolveOptions`
- document DI usage in README
- use tsyringe decorators for repository and service classes
- allow decorators by updating infrastructure tsconfigs

## Testing
- `npm run --silent --workspace=@repo/ioc lint` *(fails: Cannot find package '@repo/eslint-config')*
- `npm run --silent --workspace=@repo/ioc check-types` *(fails: Cannot find module 'tsyringe')*
- `npm run --silent --workspace=@repo/infrastructure-supabase lint` *(fails: Cannot find package '@repo/eslint-config')*
- `npm run --silent --workspace=@repo/infrastructure-supabase check-types` *(fails: Cannot find module '@repo/ioc/container')*
- `npm run --silent --workspace=@repo/infrastructure-browser check-types`


------
https://chatgpt.com/codex/tasks/task_e_68633fb74d1c83208035847f1a33dc9f